### PR TITLE
button overlap on small screens fixed

### DIFF
--- a/front-end-client/src/components/callout/callout.scss
+++ b/front-end-client/src/components/callout/callout.scss
@@ -4,4 +4,11 @@ callout {
     font-size: 1.6rem;
     font-weight: 500;
   }
+
+  @media only screen and (max-width: 640px) and (orientation: portrait) {
+    .button {
+      width: 100%;
+      box-sizing: border-box;
+    }
+  }
 }


### PR DESCRIPTION
Buttons no longer overlap on small screens. #119 