### PR TITLE
[#248] Docker database no longer uses mock data rows

### DIFF
--- a/docker/postgres/docker-entrypoint-initdb.d/init-user-db.sh
+++ b/docker/postgres/docker-entrypoint-initdb.d/init-user-db.sh
@@ -10,12 +10,5 @@ psql $POSTGRES_DB $POSTGRES_USER <<-EOSQL
     GRANT ALL PRIVILEGES ON DATABASE "$POSTGRES_DB" TO "$POSTGRES_USER";
     \connect charity
     \include /docker-entrypoint-initdb.d/mock-data/interfaith_DDL.sql
-    \include /docker-entrypoint-initdb.d/mock-data/user.sql
-    \include /docker-entrypoint-initdb.d/mock-data/callout.sql
-    \include /docker-entrypoint-initdb.d/mock-data/need.sql
-    \include /docker-entrypoint-initdb.d/mock-data/calloutneed.sql
-    \include /docker-entrypoint-initdb.d/mock-data/donor.sql
-    \include /docker-entrypoint-initdb.d/mock-data/donation.sql
-    \include /docker-entrypoint-initdb.d/mock-data/alerts.sql
     \dt
 EOSQL


### PR DESCRIPTION
## Changes
- Docker database no longer uses mock data.

I was able to create a Need row using this new setup.