### PR TITLE
Duplicate Columns Eliminated

### DIFF
--- a/donation-api/src/main/java/org/interfaithsanctuary/donationapi/model/Alert.java
+++ b/donation-api/src/main/java/org/interfaithsanctuary/donationapi/model/Alert.java
@@ -29,8 +29,8 @@ public class Alert {
     @Column(name = "need_id")
     private Integer needId;
 
-    @Column(name = "create_date")
-    private Date createDate;
+    @Column(name = "alert_created_date")
+    private Date createdDate;
 
     @Column(name = "last_pushed_date")
     private Date lastPushedDate;
@@ -76,11 +76,11 @@ public class Alert {
     	}
 
     public Date getCreateDate() {
-        return createDate;
+        return createdDate;
     }
 
-    public void setCreateDate(Date createDate) {
-        this.createDate = createDate;
+    public void setCreateDate(Date createdDate) {
+        this.createdDate = createdDate;
     }
 
     public Date getLastPushedDate() {

--- a/donation-api/src/main/java/org/interfaithsanctuary/donationapi/model/Callout.java
+++ b/donation-api/src/main/java/org/interfaithsanctuary/donationapi/model/Callout.java
@@ -22,7 +22,7 @@ public class Callout {
     @Column(name = "callout_active")
     private boolean active;
 
-    @Column(name = "callout_date_created")
+    @Column(name = "callout_created_date")
     private Date createdDate;
 
     @Column(name = "callout_description_message")


### PR DESCRIPTION
named columns same in postgres and models to get rid of duplicate column in the database (i.e. callout_create_date and callout_date_created)